### PR TITLE
changed emulator api from 22 to 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.2
     - android-27
-    - android-22
-    - sys-img-armeabi-v7a-android-22
-    - add-on
-    - extra
+    - build-tools-27.0.2
+    - extra-android-m2repository
+
 licenses:
     - 'android-sdk-license-.+'
 jdk:
@@ -19,7 +17,7 @@ before_install:
   - yes | sdkmanager "platforms;android-27"
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-16 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &


### PR DESCRIPTION
### WHAT kind of change does this PR introduce?
Makes the testing faster by speeding up the emulator boot time

source: https://medium.com/zendesk-engineering/speeding-up-android-builds-on-travis-ci-1bb4cdbd9c62

### HOW is this accomplished?
by switching the emulator api from 22 to 16 in `build.gradle`
...

### Checklist
- [x] Docs have been added / updated to reflect the changes
- [x] I have reviewed and tested the changes :white_check_mark:
- [x] I have squashed my commits to have a reasonable amount of commits

