### PR TITLE
Added Templates for all github issue times [Issue #83]

### DIFF
--- a/.github/EPIC_TEMPLATE.md
+++ b/.github/EPIC_TEMPLATE.md
@@ -1,0 +1,11 @@
+##Description
+
+*Describe the Epic*
+
+## User Stories
+
+**Story Points:**
+- [ ] User Story Name and #
+- [ ] User Story Name and #
+- [ ] User Story Name and #
+- [ ] User Story Name and #

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+**Story Points: 0 | 1 | 2 | 3 | 5 | 8 | 13 | 21**
+
+Risk: HIGH | MEDIUM | LOW
+
+Priority: HIGH | MEDIUM | LOW
+
+## Description
+*Description of the issue*
+
+## Mockup
+
+![Mockup image]()
+*Image describing the PR*
+
+## Acceptance Test
+
+| Test Reference | Test Date | Tester | Test Steps | Expected Result | Actual Result |
+|----------------|-----------|--------|------------|-----------------|---------------|
+| 1              |           |        |            |                 |               |
+| 2              |           |        |            |                 |               |
+| 3              |           |        |            |                 |               |
+| 4              |           |        |            |                 |               |
+| 5              |           |        |            |                 |               |
+
+# Tasks
+
+- [ ] **Task Name** - *x* Ideal hour(s) *TASK #*
+- [ ] **Task Name** - *x* Ideal hour(s) *TASK #*
+- [ ] **Task Name** - *x* Ideal Hour(s) *TASK #*

--- a/.github/TASK_TEMPLATE.md
+++ b/.github/TASK_TEMPLATE.md
@@ -1,0 +1,3 @@
+Task for user story #
+
+**Ideal Hours:**

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ To submit new changes to the codebase, a pull request must be opened. The pull r
   4. At least 2 independent reviews that follow the [pull request review template](https://github.com/jusleg/simple-calculator-FAMINGO/blob/master/.github/PULL_REQUEST_REVIEW_TEMPLATE.md)
   5. Code that follows the conventions outlined by the [Kotlin Foundation](https://kotlinlang.org/docs/reference/coding-conventions.html)
 
+## Submitting Issues
+
+User facing features are represented as user stories which are further broken down into tasks. Very large user stories may be broken down into multiple user stories and put into an epic. All issues submitted must follow one of the following templates.
+
+* **[User Story Template](https://github.com/jusleg/simple-calculator-FAMINGO/blob/master/.github/ISSUE_TEMPLATE.md)**
+* **[Task Template](https://github.com/jusleg/simple-calculator-FAMINGO/blob/master/.github/TASK_TEMPLATE.md)**
+* **[Epic Template](https://github.com/jusleg/simple-calculator-FAMINGO/blob/master/.github/EPIC_TEMPLATE.md)**
+
 ## Testing
 
 This app contains UI and unit tests that can be ran with the following instructions.


### PR DESCRIPTION
Fixes issue #83 

### WHAT kind of change does this PR introduce?

Adds automatic user story templates for github issues as well as templates for tasks and user stories

### HOW is this accomplished?

* README has been updated to show how issues should be created and what templates they should follow.
* Task template added into .github/ directory
* User Story template added into .github/ directory
* Epic template added into .github/ directory


### Checklist
- [x] Docs have been added / updated to reflect the changes
- [x] I have squashed my commits to have a reasonable amount of commits
