### PR TITLE
Add watch operation [US #95][Task #98]

### DIFF
--- a/wear/src/main/java/com/simpletools/calculator/wear/MainActivity.kt
+++ b/wear/src/main/java/com/simpletools/calculator/wear/MainActivity.kt
@@ -2,11 +2,14 @@ package com.simpletools.calculator.wear
 
 import android.os.Bundle
 import android.support.wearable.activity.WearableActivity
+import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
+import android.widget.LinearLayout
 import com.simplemobiletools.commons.extensions.performHapticFeedback
 import com.simpletools.calculator.commons.extensions.config
-import com.simpletools.calculator.commons.helpers.Calculator
-import com.simpletools.calculator.commons.helpers.CalculatorImpl
+import com.simpletools.calculator.commons.helpers.*
 import kotlinx.android.synthetic.main.activity_main.*
 import me.grantland.widget.AutofitHelper
 
@@ -15,6 +18,28 @@ class MainActivity : WearableActivity(), Calculator {
 
     lateinit var calc: CalculatorImpl
     private var vibrateOnButtonPress = true
+
+    lateinit var mDetector: GestureDetector
+
+
+    class SimpleGestureListener(val activity: MainActivity) : GestureDetector.SimpleOnGestureListener() {
+
+        override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
+            if(Math.abs(velocityY) > Math.abs(velocityX)){
+                if (e2!!.y > e1!!.y) {
+                    Log.d("debug","DOWN")
+                    activity.showOperations()
+                    // direction up
+                }
+            }
+            return super.onFling(e1, e2, velocityX, velocityY)
+        }
+
+        override fun onLongPress(e: MotionEvent?) {
+            super.onLongPress(e)
+            println("LONG PRESS")
+        }
+    }
 
     override fun setValue(value: String) {
         result.text = value
@@ -44,15 +69,46 @@ class MainActivity : WearableActivity(), Calculator {
             it.setOnClickListener { calc.numpadClicked(it.id); checkHaptic(it) }
         }
 
+        mDetector = GestureDetector(
+                this, SimpleGestureListener(this))
+
         btn_clear.setOnClickListener { calc.handleClear(); checkHaptic(it) }
         btn_clear.setOnLongClickListener { calc.handleReset(); true }
 
+        btn_multiply.setOnClickListener { calc.handleOperation(MULTIPLY); showNumpad() }
+        btn_minus.setOnClickListener { calc.handleOperation(MINUS); showNumpad()}
+        btn_divide.setOnClickListener { calc.handleOperation(DIVIDE);  showNumpad()}
+        btn_plus.setOnClickListener { calc.handleOperation(PLUS);  showNumpad()}
 
         btn_equals.setOnClickListener { calc.handleEquals(); }
 
         AutofitHelper.create(result)
         // Enables Always-on
         setAmbientEnabled()
+    }
+
+    fun showOperations(){
+        val linearLayout = findViewById(R.id.operation) as LinearLayout
+        linearLayout.setVisibility(View.VISIBLE);
+        val resultHeader = findViewById(R.id.result_header) as LinearLayout
+        resultHeader.setVisibility(View.GONE);
+        val numPad= findViewById(R.id.num_pad) as LinearLayout
+        numPad.setVisibility(View.GONE);
+    }
+
+    fun showNumpad(){
+        val linearLayout = findViewById(R.id.operation) as LinearLayout
+        linearLayout.setVisibility(View.GONE);
+        val resultHeader = findViewById(R.id.result_header) as LinearLayout
+        resultHeader.setVisibility(View.VISIBLE);
+        val numPad= findViewById(R.id.num_pad) as LinearLayout
+        numPad.setVisibility(View.VISIBLE);
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        Log.d("debug", "dispatchTouchEvent")
+        this.mDetector?.onTouchEvent(ev)
+        return super.dispatchTouchEvent(ev)
     }
 
     private fun getButtonIds() = arrayOf(btn_decimal, btn_0, btn_1, btn_2, btn_3, btn_4, btn_5, btn_6, btn_7, btn_8, btn_9)


### PR DESCRIPTION
### WHAT kind of change does this PR introduce?
Operations can now be completed on the calculator on the android wear interface.

<img src="https://user-images.githubusercontent.com/10934112/37630231-c9306e00-2bb9-11e8-8d51-3e61087a7bdb.gif" height=200/>


### HOW is this accomplished?
* By adding a `GestureDetector` which displays the operation screen
* Smart clear function is working on the wear ui 
* Binding of the buttons to the `CalculatorImpl` class from the commons package
...

### Checklist
- [x] Docs have been added / updated to reflect the changes
- [x] I have reviewed and tested the changes :white_check_mark:
- [x] I have squashed my commits to have a reasonable amount of commits
- [x] All of the code I have written adhere to the coding conventions outlined in the coding conventions section of the wiki
