### PR TITLE
Removed the toast on successful tax geolocation [Issue #140]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,26 @@ dependencies {
     androidTestImplementation 'com.android.support.test:rules:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
-    androidTestImplementation 'org.mockito:mockito-android:2.+'
+    androidTestImplementation 'org.mockito:mockito-android:2.16.0'
+}
+
+Properties props = new Properties()
+def propFile = new File('signing.properties')
+if (propFile.canRead()) {
+    props.load(new FileInputStream(propFile))
+
+    if (props != null && props.containsKey('STORE_FILE') && props.containsKey('KEY_ALIAS') && props.containsKey('PASSWORD')) {
+        android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+        android.signingConfigs.release.storePassword = props['PASSWORD']
+        android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+        android.signingConfigs.release.keyPassword = props['PASSWORD']
+    } else {
+        println 'signing.properties found but some entries are missing'
+        android.buildTypes.release.signingConfig = null
+    }
+} else {
+    println 'signing.properties not found'
+    android.buildTypes.release.signingConfig = null
 }
 
 repositories {

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MoneyActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MoneyActivity.kt
@@ -162,8 +162,6 @@ class MoneyActivity : SimpleActivity(), Calculator, LocationListener {
                     spawnTaxModal()
                     return
                 }
-                var message: String = String.format("Current Location: " + province + " \n Longitude: " + lastLocation.longitude + " \n Latitude: " + lastLocation.latitude)
-                Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
 
                 calc.performTaxing(province)
             }


### PR DESCRIPTION
fixes: #140 
### WHAT kind of change does this PR introduce?
This pr removes the toast upon successful tax geolocation. It was meant for development purposes. Also the gradle file was updated to fix signing properties problems and a specific version of mockito-android was picked. The newest version that came out on april 7 is breaking the tests

### HOW is this accomplished?
  * removed toast line of code
  * updated gradle

### Checklist
- [x] Docs have been added / updated to reflect the changes
- [x] I have reviewed and tested the changes :white_check_mark:
- [x] I have squashed my commits to have a reasonable amount of commits
- [x] All of the code I have written adhere to the coding conventions outlined in the coding conventions section of the wiki
