### PR TITLE
Moved compilation test before lint check [Issue #151]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ before_script:
 
 jobs:
   include:
-    - stage: Lint (ktlint) 🚲🏠
-      script: ./gradlew ktlint
     - stage: Compile (Debug, UnitTest, AndroidTest & Release) 🌚
       script: 
         - ./gradlew compileDebugAndroidTestSources
         - ./gradlew compileDebugSources
         - ./gradlew compileDebugUnitTestSources
         - ./gradlew compileReleaseSources
+    - stage: Lint (ktlint) 🚲🏠
+      script: ./gradlew ktlint
     - stage: Testing (Parallel integration & unit tests) 🏎
       script: travis_wait 30 ./testing integration_tests
     - script: ./testing unit_tests


### PR DESCRIPTION
Fixes: #151 
### WHAT kind of change does this PR introduce?
Moves the ktlint check after the compile test

### HOW is this accomplished?
updating `.travis.yml`

### Checklist
- [x] Docs have been added / updated to reflect the changes
- [x] I have reviewed and tested the changes :white_check_mark:
- [x] I have squashed my commits to have a reasonable amount of commits
- [x] All of the code I have written adhere to the coding conventions outlined in the coding conventions section of the wiki
